### PR TITLE
Change GitHub link in navbar

### DIFF
--- a/theme-config.json
+++ b/theme-config.json
@@ -7,7 +7,7 @@
     },
     "items": [
       {
-        "href": "https://github.com/facebook/docusaurus",
+        "href": "https://github.com/sam-foundation/computerization-sponsorship",
         "label": "GitHub",
         "position": "right"
       }


### PR DESCRIPTION
Don't know if the navbar GitHub link is correct, but by my understanding, it should redirect to this repo rather than to docusaurus.